### PR TITLE
Update dermatology copy and consultation details

### DIFF
--- a/components/Footer/Footer.js
+++ b/components/Footer/Footer.js
@@ -56,7 +56,7 @@ export const Footer = () => {
                             Dra. Lorraine Souza
                             <br />
                             <span className="text-[#FAF6F0]/50 text-sm">
-                                Cosmeatria · R3 em Dermatologia na UNICAMP
+                                Dermatologia · R3 em Dermatologia na UNICAMP
                             </span>
                         </p>
                         <p className="text-[#FAF6F0]/40 text-xs leading-relaxed mt-8 max-w-sm">
@@ -93,7 +93,7 @@ export const Footer = () => {
                 <div className="border-t border-[#FAF6F0]/10 py-6 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 text-xs text-[#FAF6F0]/40">
                     <span>© {year} Dra. Lorraine Souza. Todos os direitos reservados.</span>
                     <span className="tracking-[0.24em] uppercase">
-                        Cosmeatria · Mentoria · Conteúdo
+                        Dermatologia · Mentoria · Conteúdo
                     </span>
                 </div>
             </SectionContainer>

--- a/pages/consulta/index.js
+++ b/pages/consulta/index.js
@@ -7,7 +7,7 @@ import Image from "next/image";
 const stats = [
     { figure: "UNICAMP", label: "Formação em Medicina" },
     { figure: "1º lugar", label: "em Dermatologia" },
-    { figure: "40 min", label: "de videoconsulta" },
+    { figure: "1 hora", label: "de videoconsulta" },
     { figure: "14 dias", label: "de suporte pós-consulta" },
 ];
 
@@ -57,7 +57,7 @@ const nonIndications = [
 ];
 
 const included = [
-    "Videoconsulta de até 40 min",
+    "Videoconsulta de 1 hora",
     "Análise prévia do seu caso e das fotos",
     "Plano de tratamento personalizado",
     "Prescrição digital quando indicada",
@@ -106,7 +106,7 @@ export default function ConsultaPage() {
                 <section className="pt-28 lg:pt-32 pb-16 lg:pb-20">
                     <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
                         <div className="grid lg:grid-cols-[1.15fr_1fr] gap-12 lg:gap-20 items-center">
-                            <div className="order-2 lg:order-1">
+                            <div className="order-1">
                                 <MotionBTTContainer transition={{ delay: 0.1, duration: 0.6 }}>
                                     <div className="text-xs uppercase tracking-[0.28em] text-[#9A4639] font-medium mb-8">
                                         Cosmeatria · Teleconsulta
@@ -153,7 +153,7 @@ export default function ConsultaPage() {
 
                             <MotionBTTContainer
                                 transition={{ delay: 0.3, duration: 0.7 }}
-                                className="order-1 lg:order-2"
+                                className="order-2"
                             >
                                 <div className="relative max-w-[440px] mx-auto lg:max-w-none">
                                     <div
@@ -370,7 +370,7 @@ export default function ConsultaPage() {
                                             <dt className="text-xs uppercase tracking-[0.15em] text-[#57534E] mb-1.5">
                                                 CRM
                                             </dt>
-                                            <dd className="font-medium">SP · a definir</dd>
+                                            <dd className="font-medium">218676 CRM-SP</dd>
                                         </div>
                                         <div>
                                             <dt className="text-xs uppercase tracking-[0.15em] text-[#57534E] mb-1.5">

--- a/pages/index.js
+++ b/pages/index.js
@@ -10,7 +10,7 @@ const PORTRAIT_SRC = "/lolo-portrait-consulta.jpg";
 
 const stats = [
     { figure: "UNICAMP", label: "Formação em Medicina" },
-    { figure: "2023", label: "R1 em Dermatologia" },
+    { figure: "2026", label: "R3 em Dermatologia" },
     { figure: "+140", label: "Anotações de residência" },
     { figure: "São Paulo", label: "Atendimento" }
 ];
@@ -19,9 +19,9 @@ const services = [
     {
         n: "01",
         tag: "Para pacientes",
-        title: "Consulta de cosmeatria",
+        title: "Consulta de dermatologia",
         description:
-            "Videoconsulta de 40 minutos com avaliação completa, conduta personalizada e 14 dias de suporte.",
+            "Videoconsulta de 1 hora com avaliação completa, conduta personalizada e 14 dias de suporte.",
         href: "/consulta",
         cta: "Agendar consulta",
         featured: true
@@ -68,8 +68,8 @@ export default function Home() {
     return (
         <Layout>
             <SEO
-                title="Dra. Lorraine Souza | Cosmeatria · Mentoria · Residência"
-                description="Médica pela UNICAMP e R3 em Dermatologia na UNICAMP. Videoconsulta em cosmeatria, mentoria para residência médica, anotações, template Notion e currículo."
+                title="Dra. Lorraine Souza | Dermatologia · Mentoria · Residência"
+                description="Médica pela UNICAMP e R3 em Dermatologia na UNICAMP. Videoconsulta em dermatologia, mentoria para residência médica, anotações, template Notion e currículo."
             />
 
             <div className="bg-[#FAF6F0] text-[#1C1917]">
@@ -91,7 +91,7 @@ export default function Home() {
                                     transition={{ delay: 0.2, duration: 0.6 }}
                                 >
                                     <h1 className="text-[2.75rem] sm:text-5xl lg:text-[4rem] font-light leading-[1.05] tracking-[-0.02em] mb-8 text-balance">
-                                        Cosmeatria com ciência, escuta e{" "}
+                                        Dermatologia com ciência, escuta e{" "}
                                         <span className="italic text-[#9A4639]">
                                             cuidado
                                         </span>
@@ -108,7 +108,7 @@ export default function Home() {
                                         Dermatologia na UNICAMP. Atendo pacientes
                                         por videoconsulta e
                                         acompanho médicos em preparação para
-                                        residência — compartilhando o que
+                                        residência, compartilhando o que
                                         aprendi ao longo da jornada.
                                     </p>
                                 </MotionBTTContainer>
@@ -196,7 +196,7 @@ export default function Home() {
                                     className="mb-6"
                                 >
                                     <div className="text-xs uppercase tracking-[0.28em] text-[#9A4639] font-medium">
-                                        De onde eu venho
+                                        Sobre mim
                                     </div>
                                 </MotionBTTContainer>
 
@@ -204,7 +204,7 @@ export default function Home() {
                                     transition={{ delay: 0.2, duration: 0.6 }}
                                 >
                                     <h2 className="text-3xl lg:text-5xl font-light leading-[1.1] tracking-[-0.02em]">
-                                        Da Zona Leste de São Paulo ao{" "}
+                                        Médica pela UNICAMP e{" "}
                                         <span className="italic">
                                             1º lugar
                                         </span>{" "}
@@ -218,30 +218,28 @@ export default function Home() {
                             >
                                 <div className="space-y-6 text-[#3C3833] text-lg leading-relaxed">
                                     <p>
-                                        Sou paulistana, nascida na Zona Leste.
-                                        Foi em São José dos Campos que comecei
-                                        a trilhar o caminho da medicina — fiz
-                                        ensino técnico em Análises Clínicas e
-                                        estudei em um cursinho popular. Três
-                                        anos depois, passei na UNICAMP, que se
-                                        tornou minha segunda casa.
+                                        Sou médica formada pela UNICAMP, onde a
+                                        dermatologia se tornou meu foco desde a
+                                        graduação. Minha trajetória combina
+                                        estudo intenso, prática clínica e a
+                                        curiosidade constante de cuidar melhor
+                                        da pele de cada pessoa.
                                     </p>
                                     <p>
-                                        Durante a graduação me apaixonei pela
-                                        dermatologia. Após colar grau em
-                                        janeiro de 2021, dediquei dois anos à
-                                        preparação para a residência médica,
-                                        conciliando estudos, trabalho e saúde
-                                        mental.
+                                        Na preparação para a residência, conquistei
+                                        o 1º lugar em Dermatologia na UNICAMP,
+                                        além de aprovações em USP-RP, USP-SP e
+                                        PUC Campinas. Esse resultado nasceu de
+                                        método, consistência e escolhas bem
+                                        feitas ao longo do caminho.
                                     </p>
                                     <p>
-                                        Depois de muitos{" "}
-                                        <span className="italic">nãos</span>,
-                                        vieram os <em>sins</em>: UNICAMP,
-                                        USP-RP, USP-SP e PUC Campinas. Hoje,
-                                        vejo que cada passo tinha um propósito
-                                        — e é essa experiência que trago para
-                                        cada paciente e cada mentorado.
+                                        Hoje, como R3 em Dermatologia na
+                                        UNICAMP, levo essa mesma combinação de
+                                        ciência, organização e escuta para as
+                                        consultas e para a mentoria de médicos
+                                        que também estão construindo seus
+                                        próximos passos.
                                     </p>
                                 </div>
                             </MotionBTTContainer>
@@ -282,7 +280,7 @@ export default function Home() {
                                 transition={{ delay: 0.3, duration: 0.5 }}
                             >
                                 <p className="text-lg text-[#57534E] leading-relaxed">
-                                    Atendo quem busca cuidado em cosmeatria e
+                                    Atendo quem busca cuidado em dermatologia e
                                     acompanho quem está a caminho da
                                     residência.
                                 </p>


### PR DESCRIPTION
## Summary

- Updates homepage copy from Cosmeatria to Dermatologia.
- Revises the homepage “Sobre mim” section to sound more confident and highlight the 1º lugar em Dermato na UNICAMP achievement.
- Updates homepage stats from 2023 R1 to 2026 R3 em Dermatologia.
- Adjusts consultation duration copy from 40 minutes to 1 hour.
- Fixes the mobile hero order on `/consulta` so text appears before the image.
- Adds CRM number: 218676 CRM-SP.
- Updates footer labels to use Dermatologia.

## Verification

- Verified homepage copy in local preview.
- Verified `/consulta` mobile hero order at mobile breakpoint.
- Verified consultation duration and CRM text in local preview.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Service offerings updated to Dermatologia across all pages
  * Videoconsultation duration extended to 1 hour
  * Professional credentials and CRM information added
  * Homepage content refreshed, including service descriptions and professional biography

* **Layout**
  * Hero section layout optimized for improved responsiveness

<!-- end of auto-generated comment: release notes by coderabbit.ai -->