### PR TITLE
Add consulta email notifications and clarify care focus areas

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,28 @@ O projeto está hospedado em produção via [www.dralorraine.com](https://www.dr
 - Tailwind
 - Vercel
 - FontAwesome
+
+## Consulta notifications
+
+Set these env vars in Vercel to send consultation emails through Resend:
+
+- `RESEND_API_KEY`
+- `RESEND_FROM` - optional, defaults to `Dra. Lorraine <notificacoes@dralorraine.com>`
+- `NEXT_PUBLIC_SITE_URL` or `SITE_URL` - optional, used for email links
+- `CONSULTA_ADMIN_EMAIL_TO` - optional, defaults to `adias7882@gmail.com,lorraine.tfc@gmail.com`
+- `RESEND_ADMIN_APPOINTMENT_PURCHASED_TEMPLATE_ID` - published Resend template for the admin payment-confirmed email
+- `RESEND_PATIENT_PAYMENT_CONFIRMED_TEMPLATE_ID` - published Resend template for the patient payment-confirmed email
+- `CONSULTA_COMPLETED_EMAIL_TO` - optional scheduled-consultation recipients
+- `RESEND_CONSULTA_COMPLETED_TEMPLATE_ID` - optional published Resend template id or alias
+
+Payment-confirmed templates use these variables: `CONSULTATION_ID`, `CONSULTATION_PRICE`, `PATIENT_FIRST_NAME`, `PATIENT_NAME`, `PATIENT_MAIL`, `PATIENT_PHONE`, `PATIENT_CITY`, `MAIN_CONCERN`, `PAYMENT_PROVIDER`, `PAYMENT_PROVIDER_REF`, `ADMIN_URL`, `SCHEDULING_URL`.
+
+Scheduled-consultation templates use these variables: `CONSULTATION_ID`, `PATIENT_NAME`, `PATIENT_MAIL`, `PATIENT_PHONE`, `SCHEDULED_AT`, `SCHEDULED_TIMEZONE`, `SCHEDULING_PROVIDER`, `SCHEDULING_PROVIDER_REF`, `ADMIN_URL`.
+
+Local email testing:
+
+- Preview variables without sending: `curl http://localhost:3001/api/dev/consulta-payment-emails`
+- Send both payment-confirmed test emails to one inbox:
+  `curl -X POST http://localhost:3001/api/dev/consulta-payment-emails -H "Content-Type: application/json" -d '{"adminTo":"you@example.com","patientTo":"you@example.com"}'`
+
+The dev test endpoint returns 404 in production.

--- a/docs/email-templates/admin-appointment-purchased.html
+++ b/docs/email-templates/admin-appointment-purchased.html
@@ -1,0 +1,86 @@
+<!doctype html>
+<html lang="pt-BR">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>Nova consulta comprada</title>
+    </head>
+    <body style="margin:0; padding:0; background:#FAF6F0; color:#1C1917; font-family:Arial, Helvetica, sans-serif;">
+        <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background:#FAF6F0; margin:0; padding:0;">
+            <tr>
+                <td align="center" style="padding:32px 16px;">
+                    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="max-width:640px; background:#FFFFFF; border:1px solid #E7E2D9;">
+                        <tr>
+                            <td style="padding:36px 36px 24px;">
+                                <div style="font-size:12px; line-height:1.4; letter-spacing:0.22em; text-transform:uppercase; color:#9A4639; font-weight:700;">
+                                    Agendamento recebido
+                                </div>
+                                <h1 style="margin:18px 0 12px; font-size:30px; line-height:1.15; font-weight:400; color:#1C1917;">
+                                    Nova consulta comprada pelo site.
+                                </h1>
+                                <p style="margin:0; font-size:16px; line-height:1.65; color:#57534E;">
+                                    O pagamento de {{PATIENT_NAME}} foi processado. O próximo passo da paciente é escolher o horário da videoconsulta.
+                                </p>
+                            </td>
+                        </tr>
+
+                        <tr>
+                            <td style="padding:0 36px 8px;">
+                                <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background:#1C1917; color:#FAF6F0;">
+                                    <tr>
+                                        <td style="padding:28px;">
+                                            <div style="font-size:11px; line-height:1.4; letter-spacing:0.22em; text-transform:uppercase; color:#E4B5AC; font-weight:700;">
+                                                Resumo do pagamento
+                                            </div>
+                                            <p style="margin:16px 0 0; font-size:26px; line-height:1.25; font-weight:400; color:#FAF6F0;">
+                                                {{CONSULTATION_PRICE}}
+                                            </p>
+                                            <p style="margin:8px 0 0; font-size:13px; line-height:1.6; color:#D8D0C7;">
+                                                Consulta ID {{CONSULTATION_ID}} · {{PAYMENT_PROVIDER}} {{PAYMENT_PROVIDER_REF}}
+                                            </p>
+                                        </td>
+                                    </tr>
+                                </table>
+                            </td>
+                        </tr>
+
+                        <tr>
+                            <td style="padding:24px 36px 8px;">
+                                <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="border-collapse:collapse;">
+                                    <tr>
+                                        <td style="padding:12px 0; border-bottom:1px solid #E7E2D9; color:#57534E; font-size:13px;">Paciente</td>
+                                        <td align="right" style="padding:12px 0; border-bottom:1px solid #E7E2D9; color:#1C1917; font-size:14px; font-weight:700;">{{PATIENT_NAME}}</td>
+                                    </tr>
+                                    <tr>
+                                        <td style="padding:12px 0; border-bottom:1px solid #E7E2D9; color:#57534E; font-size:13px;">Email</td>
+                                        <td align="right" style="padding:12px 0; border-bottom:1px solid #E7E2D9; color:#1C1917; font-size:14px; font-weight:700;">{{PATIENT_MAIL}}</td>
+                                    </tr>
+                                    <tr>
+                                        <td style="padding:12px 0; border-bottom:1px solid #E7E2D9; color:#57534E; font-size:13px;">Telefone</td>
+                                        <td align="right" style="padding:12px 0; border-bottom:1px solid #E7E2D9; color:#1C1917; font-size:14px; font-weight:700;">{{PATIENT_PHONE}}</td>
+                                    </tr>
+                                    <tr>
+                                        <td style="padding:12px 0; border-bottom:1px solid #E7E2D9; color:#57534E; font-size:13px;">Cidade</td>
+                                        <td align="right" style="padding:12px 0; border-bottom:1px solid #E7E2D9; color:#1C1917; font-size:14px; font-weight:700;">{{PATIENT_CITY}}</td>
+                                    </tr>
+                                    <tr>
+                                        <td style="padding:12px 0; border-bottom:1px solid #E7E2D9; color:#57534E; font-size:13px;">Queixa principal</td>
+                                        <td align="right" style="padding:12px 0; border-bottom:1px solid #E7E2D9; color:#1C1917; font-size:14px; font-weight:700;">{{MAIN_CONCERN}}</td>
+                                    </tr>
+                                </table>
+                            </td>
+                        </tr>
+
+                        <tr>
+                            <td style="padding:24px 36px 36px;">
+                                <p style="margin:0; font-size:13px; line-height:1.6; color:#57534E;">
+                                    Este email foi enviado automaticamente quando o pagamento da consulta foi confirmado.
+                                </p>
+                            </td>
+                        </tr>
+                    </table>
+                </td>
+            </tr>
+        </table>
+    </body>
+</html>

--- a/docs/email-templates/patient-payment-confirmed.html
+++ b/docs/email-templates/patient-payment-confirmed.html
@@ -1,0 +1,114 @@
+<!doctype html>
+<html lang="pt-BR">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>Pagamento confirmado</title>
+    </head>
+    <body style="margin:0; padding:0; background:#FAF6F0; color:#1C1917; font-family:Arial, Helvetica, sans-serif;">
+        <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background:#FAF6F0; margin:0; padding:0;">
+            <tr>
+                <td align="center" style="padding:32px 16px;">
+                    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="max-width:640px; background:#FFFFFF; border:1px solid #E7E2D9;">
+                        <tr>
+                            <td style="padding:36px 36px 20px;">
+                                <div style="font-size:12px; line-height:1.4; letter-spacing:0.22em; text-transform:uppercase; color:#9A4639; font-weight:700;">
+                                    Pagamento confirmado
+                                </div>
+                                <h1 style="margin:18px 0 12px; font-size:32px; line-height:1.15; font-weight:400; color:#1C1917;">
+                                    Tudo certo, {{PATIENT_FIRST_NAME}}.
+                                </h1>
+                                <p style="margin:0; font-size:16px; line-height:1.7; color:#57534E;">
+                                    Seu pagamento foi processado com sucesso. Agora falta só escolher o melhor horário para sua videoconsulta com a Dra. Lorraine.
+                                </p>
+                            </td>
+                        </tr>
+
+                        <tr>
+                            <td style="padding:0 36px 8px;">
+                                <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background:#1C1917; color:#FAF6F0;">
+                                    <tr>
+                                        <td style="padding:28px;">
+                                            <div style="font-size:11px; line-height:1.4; letter-spacing:0.22em; text-transform:uppercase; color:#E4B5AC; font-weight:700;">
+                                                Próximo passo
+                                            </div>
+                                            <p style="margin:16px 0 0; font-size:22px; line-height:1.35; font-weight:400; color:#FAF6F0;">
+                                                Agende sua consulta para garantir o horário que funciona melhor para você.
+                                            </p>
+                                            <p style="margin:12px 0 0; font-size:14px; line-height:1.65; color:#D8D0C7;">
+                                                O link abaixo leva você de volta ao fluxo de agendamento, com seus dados salvos.
+                                            </p>
+                                        </td>
+                                    </tr>
+                                </table>
+                            </td>
+                        </tr>
+
+                        <tr>
+                            <td style="padding:24px 36px 8px;">
+                                <a href="{{SCHEDULING_URL}}" style="display:inline-block; background:#1C1917; color:#FAF6F0; text-decoration:none; padding:15px 24px; font-size:14px; font-weight:700;">
+                                    Escolher meu horário
+                                </a>
+                            </td>
+                        </tr>
+
+                        <tr>
+                            <td style="padding:24px 36px 8px;">
+                                <h2 style="margin:0 0 14px; font-size:18px; line-height:1.35; font-weight:400; color:#1C1917;">
+                                    Resumo da sua consulta
+                                </h2>
+                                <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="border-collapse:collapse;">
+                                    <tr>
+                                        <td style="padding:12px 0; border-bottom:1px solid #E7E2D9; color:#57534E; font-size:13px;">Nome</td>
+                                        <td align="right" style="padding:12px 0; border-bottom:1px solid #E7E2D9; color:#1C1917; font-size:14px; font-weight:700;">{{PATIENT_NAME}}</td>
+                                    </tr>
+                                    <tr>
+                                        <td style="padding:12px 0; border-bottom:1px solid #E7E2D9; color:#57534E; font-size:13px;">Email</td>
+                                        <td align="right" style="padding:12px 0; border-bottom:1px solid #E7E2D9; color:#1C1917; font-size:14px; font-weight:700;">{{PATIENT_MAIL}}</td>
+                                    </tr>
+                                    <tr>
+                                        <td style="padding:12px 0; border-bottom:1px solid #E7E2D9; color:#57534E; font-size:13px;">Telefone</td>
+                                        <td align="right" style="padding:12px 0; border-bottom:1px solid #E7E2D9; color:#1C1917; font-size:14px; font-weight:700;">{{PATIENT_PHONE}}</td>
+                                    </tr>
+                                    <tr>
+                                        <td style="padding:12px 0; border-bottom:1px solid #E7E2D9; color:#57534E; font-size:13px;">Valor</td>
+                                        <td align="right" style="padding:12px 0; border-bottom:1px solid #E7E2D9; color:#1C1917; font-size:14px; font-weight:700;">{{CONSULTATION_PRICE}}</td>
+                                    </tr>
+                                    <tr>
+                                        <td style="padding:12px 0; border-bottom:1px solid #E7E2D9; color:#57534E; font-size:13px;">Consulta ID</td>
+                                        <td align="right" style="padding:12px 0; border-bottom:1px solid #E7E2D9; color:#1C1917; font-size:14px; font-weight:700;">{{CONSULTATION_ID}}</td>
+                                    </tr>
+                                </table>
+                            </td>
+                        </tr>
+
+                        <tr>
+                            <td style="padding:24px 36px 8px;">
+                                <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background:#FAF6F0; border-left:2px solid #9A4639;">
+                                    <tr>
+                                        <td style="padding:18px 20px;">
+                                            <p style="margin:0; font-size:14px; line-height:1.7; color:#57534E;">
+                                                Para deixar a experiência mais fluida, separe alguns minutos em um ambiente tranquilo para escolher o horário. Depois do agendamento, você receberá as instruções finais para a videoconsulta.
+                                            </p>
+                                        </td>
+                                    </tr>
+                                </table>
+                            </td>
+                        </tr>
+
+                        <tr>
+                            <td style="padding:24px 36px 36px;">
+                                <p style="margin:0; font-size:15px; line-height:1.7; color:#57534E;">
+                                    Obrigada por confiar na Dra. Lorraine. Agora vamos preparar uma consulta tranquila, objetiva e bem personalizada para o que você precisa.
+                                </p>
+                                <p style="margin:20px 0 0; font-size:13px; line-height:1.6; color:#8A8178;">
+                                    Se o botão não funcionar, copie este link no navegador: {{SCHEDULING_URL}}
+                                </p>
+                            </td>
+                        </tr>
+                    </table>
+                </td>
+            </tr>
+        </table>
+    </body>
+</html>

--- a/pages/api/dev/consulta-payment-emails.js
+++ b/pages/api/dev/consulta-payment-emails.js
@@ -1,0 +1,90 @@
+import {
+    getConsultaPaymentTemplateVariables,
+    safeNotifyConsultaPaymentConfirmed
+} from "@utils/consultaNotifications";
+
+function hasValue(value) {
+    return Boolean(String(value || "").trim());
+}
+
+function buildMockConsultation(body = {}) {
+    const now = Date.now();
+
+    return {
+        id: body.id || `test-${now}`,
+        name: body.name || "Marina Teste da Silva",
+        email: body.email || "paciente.teste@example.com",
+        phone: body.phone || "(11) 99999-0000",
+        city: body.city || "Sao Paulo",
+        mainConcern:
+            body.mainConcern ||
+            "Manchas no rosto e rotina de cuidados para pele sensivel",
+        paymentProvider: body.paymentProvider || "stripe",
+        paymentProviderRef: body.paymentProviderRef || `test-payment-${now}`
+    };
+}
+
+function getEnvStatus() {
+    return {
+        hasResendApiKey: hasValue(process.env.RESEND_API_KEY),
+        resendFrom:
+            process.env.RESEND_FROM ||
+            "Dra. Lorraine <notificacoes@dralorraine.com>",
+        hasAdminTemplate: hasValue(
+            process.env.RESEND_ADMIN_APPOINTMENT_PURCHASED_TEMPLATE_ID
+        ),
+        hasPatientTemplate: hasValue(
+            process.env.RESEND_PATIENT_PAYMENT_CONFIRMED_TEMPLATE_ID
+        ),
+        adminRecipients:
+            process.env.CONSULTA_ADMIN_EMAIL_TO ||
+            "adias7882@gmail.com,lorraine.tfc@gmail.com",
+        siteUrl:
+            process.env.NEXT_PUBLIC_SITE_URL ||
+            process.env.SITE_URL ||
+            process.env.siteUrl ||
+            "https://dralorraine.com.br"
+    };
+}
+
+export default async function handler(req, res) {
+    if (process.env.NODE_ENV === "production") {
+        res.status(404).json({ error: "Not found" });
+        return;
+    }
+
+    if (!["GET", "POST"].includes(req.method)) {
+        res.status(405).json({ error: "Method not allowed" });
+        return;
+    }
+
+    const body = req.method === "POST" ? req.body || {} : {};
+    const consultation = buildMockConsultation(body);
+    const variables = getConsultaPaymentTemplateVariables(consultation);
+    const env = getEnvStatus();
+
+    if (req.method === "GET" || body.dryRun) {
+        res.status(200).json({
+            dryRun: true,
+            message:
+                "These are the exact variables that would be sent to the Resend templates.",
+            env,
+            consultation,
+            variables
+        });
+        return;
+    }
+
+    const result = await safeNotifyConsultaPaymentConfirmed(consultation, {
+        adminRecipients: body.adminTo,
+        patientRecipient: body.patientTo || body.email
+    });
+
+    res.status(result?.error ? 500 : 200).json({
+        dryRun: false,
+        env,
+        consultation,
+        variables,
+        result
+    });
+}

--- a/pages/api/payments/confirm.js
+++ b/pages/api/payments/confirm.js
@@ -1,5 +1,6 @@
 import { sql } from "@vercel/postgres";
 import { getPaymentProvider } from "@utils/integrations/payment";
+import { safeNotifyConsultaPaymentConfirmed } from "@utils/consultaNotifications";
 
 export default async function handler(req, res) {
     if (req.method !== "POST") {
@@ -34,7 +35,9 @@ export default async function handler(req, res) {
         }
 
         const { rows } = await sql`
-            SELECT id, status, payment_status
+            SELECT
+                id, name, email, phone, city, main_concern,
+                status, payment_status
             FROM consultations
             WHERE id = ${consultationId}
             LIMIT 1;
@@ -76,6 +79,19 @@ export default async function handler(req, res) {
                 paid_at = COALESCE(paid_at, ${confirmation.paidAt})
             WHERE id = ${consultationId};
         `;
+
+        if (confirmation.paymentStatus === "paid") {
+            await safeNotifyConsultaPaymentConfirmed({
+                id: consultation.id,
+                name: consultation.name,
+                email: consultation.email,
+                phone: consultation.phone,
+                city: consultation.city,
+                mainConcern: consultation.main_concern,
+                paymentProvider: confirmation.provider,
+                paymentProviderRef: confirmation.providerRef
+            });
+        }
 
         res.status(200).json({
             paid: confirmation.paymentStatus === "paid",

--- a/pages/api/payments/webhook/[provider].js
+++ b/pages/api/payments/webhook/[provider].js
@@ -1,5 +1,6 @@
 import { sql } from "@vercel/postgres";
 import { getPaymentProvider } from "@utils/integrations/payment";
+import { safeNotifyConsultaPaymentConfirmed } from "@utils/consultaNotifications";
 
 export const config = {
     api: {
@@ -43,6 +44,15 @@ export default async function handler(req, res) {
             rawBody,
             body
         });
+        const { rows } = await sql`
+            SELECT
+                id, name, email, phone, city, main_concern,
+                status, payment_status
+            FROM consultations
+            WHERE id = ${event.consultationId}
+            LIMIT 1;
+        `;
+        const consultation = rows[0];
 
         await sql`
             UPDATE consultations
@@ -57,6 +67,25 @@ export default async function handler(req, res) {
                 hotmart_transaction_id = COALESCE(hotmart_transaction_id, ${event.providerRef})
             WHERE id = ${event.consultationId};
         `;
+
+        if (
+            event.paymentStatus === "paid" &&
+            consultation &&
+            consultation.payment_status !== "paid" &&
+            consultation.status !== "paid" &&
+            consultation.status !== "scheduled"
+        ) {
+            await safeNotifyConsultaPaymentConfirmed({
+                id: consultation.id,
+                name: consultation.name,
+                email: consultation.email,
+                phone: consultation.phone,
+                city: consultation.city,
+                mainConcern: consultation.main_concern,
+                paymentProvider: event.provider,
+                paymentProviderRef: event.providerRef
+            });
+        }
 
         res.status(200).json({ ok: true });
     } catch (err) {

--- a/pages/api/scheduling/book.js
+++ b/pages/api/scheduling/book.js
@@ -1,5 +1,6 @@
 import { sql } from "@vercel/postgres";
 import { getSchedulingProvider } from "@utils/integrations/scheduling";
+import { safeNotifyConsultaCompleted } from "@utils/consultaNotifications";
 
 export default async function handler(req, res) {
     if (req.method !== "POST") {
@@ -18,7 +19,7 @@ export default async function handler(req, res) {
     try {
         const provider = getSchedulingProvider();
         const { rows } = await sql`
-            SELECT id, name, email, phone, payment_status
+            SELECT id, name, email, phone, payment_status, status, scheduling_status
             FROM consultations
             WHERE id = ${consultationId}
             LIMIT 1;
@@ -53,6 +54,22 @@ export default async function handler(req, res) {
                 scheduling_metadata = ${JSON.stringify(booking.metadata || {})}::jsonb
             WHERE id = ${consultationId};
         `;
+
+        if (
+            consultation.status !== "scheduled" &&
+            consultation.scheduling_status !== "scheduled"
+        ) {
+            await safeNotifyConsultaCompleted({
+                id: consultation.id,
+                name: consultation.name,
+                email: consultation.email,
+                phone: consultation.phone,
+                scheduledAt: booking.scheduledAt,
+                scheduledTimezone: booking.scheduledTimezone,
+                schedulingProvider: booking.provider,
+                schedulingProviderRef: booking.providerRef
+            });
+        }
 
         res.status(200).json(booking);
     } catch (err) {

--- a/pages/api/scheduling/webhook/[provider].js
+++ b/pages/api/scheduling/webhook/[provider].js
@@ -1,5 +1,6 @@
 import { sql } from "@vercel/postgres";
 import { getSchedulingProvider } from "@utils/integrations/scheduling";
+import { safeNotifyConsultaCompleted } from "@utils/consultaNotifications";
 
 export default async function handler(req, res) {
     if (req.method !== "POST") {
@@ -10,6 +11,13 @@ export default async function handler(req, res) {
     try {
         const provider = getSchedulingProvider(req.query.provider);
         const event = provider.parseWebhook({ req });
+        const { rows } = await sql`
+            SELECT id, name, email, phone, status, scheduling_status
+            FROM consultations
+            WHERE id = ${event.consultationId}
+            LIMIT 1;
+        `;
+        const consultation = rows[0];
 
         await sql`
             UPDATE consultations
@@ -23,6 +31,24 @@ export default async function handler(req, res) {
                 scheduling_metadata = ${JSON.stringify(event.metadata || {})}::jsonb
             WHERE id = ${event.consultationId};
         `;
+
+        if (
+            event.consultationStatus === "scheduled" &&
+            consultation &&
+            consultation.status !== "scheduled" &&
+            consultation.scheduling_status !== "scheduled"
+        ) {
+            await safeNotifyConsultaCompleted({
+                id: consultation.id,
+                name: consultation.name,
+                email: consultation.email,
+                phone: consultation.phone,
+                scheduledAt: event.scheduledAt,
+                scheduledTimezone: event.scheduledTimezone,
+                schedulingProvider: event.provider,
+                schedulingProviderRef: event.providerRef
+            });
+        }
 
         res.status(200).json({ ok: true });
     } catch (err) {

--- a/pages/consentimento-telemedicina/index.js
+++ b/pages/consentimento-telemedicina/index.js
@@ -7,7 +7,7 @@ export default function TelemedicineConsent() {
         <Layout>
             <SEO
                 title="Consentimento para Telemedicina | Dra. Lorraine"
-                description="Termo de consentimento informado para atendimento em cosmeatria por telemedicina, conforme a Resolução CFM 2.314/2022."
+                description="Termo de consentimento informado para atendimento em dermatologia por telemedicina, conforme a Resolução CFM 2.314/2022."
             />
             <div className="main-wrapper bg-[#FBF7F2] pt-28 pb-20 min-h-screen">
                 <div className="max-w-3xl mx-auto px-4 sm:px-6">

--- a/pages/consulta/agendar/index.js
+++ b/pages/consulta/agendar/index.js
@@ -159,7 +159,7 @@ export default function AgendarPage() {
         <Layout>
             <SEO
                 title="Agendar Consulta | Dra. Lorraine Souza"
-                description="Agende sua videoconsulta de cosmeatria em poucos passos. Suas respostas ficam salvas — você pode voltar depois para continuar."
+                description="Agende sua videoconsulta de dermatologia em poucos passos. Suas respostas ficam salvas — você pode voltar depois para continuar."
                 image="/lolo-portrait-consulta.jpg"
                 url="/consulta/agendar"
             />
@@ -1418,7 +1418,7 @@ function StepPayment({
 
             <div className="bg-[#1C1917] text-[#FAF6F0] p-8 lg:p-10">
                 <div className="text-xs uppercase tracking-[0.28em] text-[#E4B5AC] font-medium mb-6">
-                    Videoconsulta · Cosmeatria
+                    Videoconsulta · Dermatologia
                 </div>
 
                 <div className="border-t border-[#FAF6F0]/15 pt-6 mb-6">

--- a/pages/consulta/index.js
+++ b/pages/consulta/index.js
@@ -49,10 +49,28 @@ const indications = [
     "Revisão de tratamentos",
 ];
 
+const focusAreas = [
+    {
+        title: "Cosmiatria",
+        description:
+            "Planejamento de cuidados e procedimentos estéticos, como toxina botulínica, preenchimentos, lasers, bioestimuladores e melhora global da qualidade da pele.",
+    },
+    {
+        title: "Dermatologia clínica",
+        description:
+            "Avaliação de acne, rosácea, melasma, dermatites, queda de cabelo, alergias, manchas, pintas e outras queixas comuns da pele, cabelos e unhas.",
+    },
+    {
+        title: "Dermatologia cirúrgica",
+        description:
+            "Orientação sobre câncer de pele, cistos, verrugas, lipomas e lesões que podem precisar de exame presencial, biópsia ou retirada cirúrgica.",
+    },
+];
+
 const nonIndications = [
-    "Lesões suspeitas que exijam biópsia presencial",
-    "Procedimentos estéticos (botox, preenchimento, lasers)",
-    "Cirurgias dermatológicas",
+    "Biópsias e retirada de lesões",
+    "Aplicação de toxina botulínica, preenchimentos, lasers e outros procedimentos",
+    "Cirurgias dermatológicas presenciais",
     "Urgências ou emergências médicas",
 ];
 
@@ -242,6 +260,56 @@ export default function ConsultaPage() {
                     </div>
                 </section>
 
+                {/* ============ FOCUS AREAS ============ */}
+                <section className="py-20 lg:py-24 border-t border-[#E7E2D9]">
+                    <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+                        <MotionBTTContainer transition={{ delay: 0.1, duration: 0.5 }}>
+                            <div className="grid lg:grid-cols-[0.85fr_1.15fr] gap-12 lg:gap-20">
+                                <div>
+                                    <div className="text-xs uppercase tracking-[0.28em] text-[#9A4639] font-medium mb-6">
+                                        Foco do atendimento
+                                    </div>
+                                    <h2 className="text-3xl lg:text-5xl font-light leading-[1.1] tracking-[-0.02em] mb-6">
+                                        Dermatologia para tratar, prevenir e{" "}
+                                        <span className="italic text-[#9A4639]">
+                                            planejar
+                                        </span>
+                                        .
+                                    </h2>
+                                    <p className="text-lg text-[#57534E] leading-relaxed">
+                                        Na videoconsulta, a Dra. Lorraine avalia sua
+                                        história, suas fotos e seus objetivos para
+                                        orientar o melhor caminho. Quando houver
+                                        necessidade de procedimento ou cirurgia, você
+                                        recebe uma indicação clara dos próximos passos.
+                                    </p>
+                                </div>
+
+                                <div className="space-y-6">
+                                    {focusAreas.map((area, i) => (
+                                        <MotionBTTContainer
+                                            key={area.title}
+                                            transition={{
+                                                delay: 0.2 + i * 0.08,
+                                                duration: 0.5,
+                                            }}
+                                        >
+                                            <div className="border-t border-[#1C1917] pt-6">
+                                                <h3 className="text-xl font-medium tracking-tight text-[#1C1917] mb-3">
+                                                    {area.title}
+                                                </h3>
+                                                <p className="text-[#57534E] leading-relaxed">
+                                                    {area.description}
+                                                </p>
+                                            </div>
+                                        </MotionBTTContainer>
+                                    ))}
+                                </div>
+                            </div>
+                        </MotionBTTContainer>
+                    </div>
+                </section>
+
                 {/* ============ FOR WHOM ============ */}
                 <section className="py-20 lg:py-24 border-t border-[#E7E2D9] bg-[#F3EADB]">
                     <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -289,7 +357,7 @@ export default function ConsultaPage() {
                             >
                                 <div>
                                     <div className="text-xs uppercase tracking-[0.22em] text-[#57534E] font-medium mb-5 pb-5 border-b border-[#E7E2D9]">
-                                        Requer avaliação presencial
+                                        Pode exigir etapa presencial
                                     </div>
                                     <ul className="space-y-3 text-[#1C1917] mb-8">
                                         {nonIndications.map((item, i) => (
@@ -305,9 +373,10 @@ export default function ConsultaPage() {
                                         ))}
                                     </ul>
                                     <p className="text-sm text-[#57534E] leading-relaxed border-t border-[#E7E2D9] pt-6">
-                                        Se identificarmos a necessidade de uma avaliação
-                                        presencial, você é orientado sobre os próximos
-                                        passos — sem custo adicional.
+                                        A teleconsulta ajuda a entender o caso e planejar
+                                        a conduta. Se houver necessidade de exame,
+                                        procedimento ou cirurgia, você recebe orientação
+                                        sobre os próximos passos.
                                     </p>
                                 </div>
                             </MotionBTTContainer>

--- a/pages/consulta/index.js
+++ b/pages/consulta/index.js
@@ -98,8 +98,8 @@ export default function ConsultaPage() {
     return (
         <Layout>
             <SEO
-                title="Consulta Online de Cosmeatria | Dra. Lorraine"
-                description="Agende uma videoconsulta de cosmeatria com a Dra. Lorraine, médica pela UNICAMP e R3 em Dermatologia na UNICAMP."
+                title="Consulta Online de Dermatologia | Dra. Lorraine"
+                description="Agende uma videoconsulta de dermatologia com a Dra. Lorraine, médica pela UNICAMP e R3 em Dermatologia na UNICAMP."
             />
             <div className="main-wrapper relative z-10 bg-[#FAF6F0] text-[#1C1917]">
                 {/* ============ HERO ============ */}
@@ -109,7 +109,7 @@ export default function ConsultaPage() {
                             <div className="order-1">
                                 <MotionBTTContainer transition={{ delay: 0.1, duration: 0.6 }}>
                                     <div className="text-xs uppercase tracking-[0.28em] text-[#9A4639] font-medium mb-8">
-                                        Cosmeatria · Teleconsulta
+                                        Dermatologia · Teleconsulta
                                     </div>
                                 </MotionBTTContainer>
                                 <MotionBTTContainer transition={{ delay: 0.2, duration: 0.6 }}>
@@ -376,7 +376,7 @@ export default function ConsultaPage() {
                                             <dt className="text-xs uppercase tracking-[0.15em] text-[#57534E] mb-1.5">
                                                 Foco
                                             </dt>
-                                            <dd className="font-medium">Cosmeatria</dd>
+                                            <dd className="font-medium">Dermatologia</dd>
                                         </div>
                                     </dl>
                                 </div>

--- a/pages/politica-de-privacidade/index.js
+++ b/pages/politica-de-privacidade/index.js
@@ -84,7 +84,7 @@ export default function PrivacyPolicy() {
                                 </h2>
                                 <ul className="list-disc pl-6 space-y-1">
                                     <li>
-                                        Prestar o atendimento em cosmeatria
+                                        Prestar o atendimento em dermatologia
                                         solicitado.
                                     </li>
                                     <li>

--- a/pages/termos-de-uso/index.js
+++ b/pages/termos-de-uso/index.js
@@ -7,7 +7,7 @@ export default function TermsOfUse() {
         <Layout>
             <SEO
                 title="Termos de Uso | Dra. Lorraine"
-                description="Termos e condições do serviço de consulta online de cosmeatria."
+                description="Termos e condições do serviço de consulta online de dermatologia."
             />
             <div className="main-wrapper bg-[#FBF7F2] pt-28 pb-20 min-h-screen">
                 <div className="max-w-3xl mx-auto px-4 sm:px-6">
@@ -43,7 +43,7 @@ export default function TermsOfUse() {
                                 </h2>
                                 <p>
                                     O serviço consiste em uma videoconsulta
-                                    de cosmeatria de até 40 minutos, realizada via
+                                    de dermatologia de até 40 minutos, realizada via
                                     videoconferência por profissional regularmente
                                     inscrito no Conselho Regional de Medicina.
                                 </p>

--- a/utils/consultaNotifications.js
+++ b/utils/consultaNotifications.js
@@ -1,0 +1,324 @@
+function formatDateTime(value, timeZone) {
+    if (!value) return "horario nao informado";
+
+    try {
+        return new Intl.DateTimeFormat("pt-BR", {
+            dateStyle: "short",
+            timeStyle: "short",
+            timeZone: timeZone || "America/Sao_Paulo"
+        }).format(new Date(value));
+    } catch (err) {
+        return String(value);
+    }
+}
+
+function escapeHtml(value) {
+    return String(value || "")
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#039;");
+}
+
+function parseRecipients(value) {
+    return String(value || "")
+        .split(",")
+        .map((email) => email.trim())
+        .filter(Boolean);
+}
+
+function formatConsultationPrice() {
+    const amountInCents = Number(process.env.STRIPE_CONSULTATION_PRICE_CENTS);
+
+    if (amountInCents > 0) {
+        return new Intl.NumberFormat("pt-BR", {
+            style: "currency",
+            currency: "BRL"
+        }).format(amountInCents / 100);
+    }
+
+    return process.env.CONSULTATION_PRICE_LABEL || "R$ 350";
+}
+
+function firstName(name) {
+    return String(name || "paciente").trim().split(/\s+/)[0] || "paciente";
+}
+
+function siteUrl() {
+    return (
+        process.env.NEXT_PUBLIC_SITE_URL ||
+        process.env.SITE_URL ||
+        process.env.siteUrl ||
+        "https://dralorraine.com.br"
+    ).replace(/\/$/, "");
+}
+
+function buildCompletedMessage(consultation) {
+    const scheduledAt = formatDateTime(
+        consultation.scheduledAt,
+        consultation.scheduledTimezone
+    );
+
+    return [
+        "Nova consulta agendada pelo site",
+        `Paciente: ${consultation.name || "Nao informado"}`,
+        `Email: ${consultation.email || "Nao informado"}`,
+        `Telefone: ${consultation.phone || "Nao informado"}`,
+        `Horario: ${scheduledAt}`,
+        `Consulta ID: ${consultation.id}`
+    ].join("\n");
+}
+
+function getAdminUrl(consultationId) {
+    return `${siteUrl()}/admin/consultas?consulta=${consultationId}`;
+}
+
+function getSchedulingUrl(consultationId) {
+    return `${siteUrl()}/consulta/agendar?consulta=${consultationId}`;
+}
+
+function buildTemplateVariables(consultation) {
+    const scheduledAt = formatDateTime(
+        consultation.scheduledAt,
+        consultation.scheduledTimezone
+    );
+
+    return {
+        CONSULTATION_ID: String(consultation.id || ""),
+        PATIENT_NAME: consultation.name || "Nao informado",
+        PATIENT_MAIL: consultation.email || "Nao informado",
+        PATIENT_PHONE: consultation.phone || "Nao informado",
+        SCHEDULED_AT: scheduledAt,
+        SCHEDULED_TIMEZONE:
+            consultation.scheduledTimezone || "America/Sao_Paulo",
+        SCHEDULING_PROVIDER: consultation.schedulingProvider || "",
+        SCHEDULING_PROVIDER_REF: consultation.schedulingProviderRef || "",
+        ADMIN_URL: getAdminUrl(consultation.id)
+    };
+}
+
+export function getConsultaPaymentTemplateVariables(consultation) {
+    return {
+        CONSULTATION_ID: String(consultation.id || ""),
+        CONSULTATION_PRICE: formatConsultationPrice(),
+        PATIENT_FIRST_NAME: firstName(consultation.name),
+        PATIENT_NAME: consultation.name || "Nao informado",
+        PATIENT_MAIL: consultation.email || "Nao informado",
+        PATIENT_PHONE: consultation.phone || "Nao informado",
+        PATIENT_CITY: consultation.city || "Nao informado",
+        MAIN_CONCERN: consultation.mainConcern || "Nao informado",
+        PAYMENT_PROVIDER: consultation.paymentProvider || "",
+        PAYMENT_PROVIDER_REF: consultation.paymentProviderRef || "",
+        ADMIN_URL: getAdminUrl(consultation.id),
+        SCHEDULING_URL: getSchedulingUrl(consultation.id)
+    };
+}
+
+function buildFallbackHtml(variables) {
+    const rows = [
+        ["Paciente", variables.PATIENT_NAME],
+        ["Email", variables.PATIENT_MAIL],
+        ["Telefone", variables.PATIENT_PHONE],
+        ["Horario", variables.SCHEDULED_AT],
+        ["Consulta ID", variables.CONSULTATION_ID],
+        ["Provedor", variables.SCHEDULING_PROVIDER]
+    ];
+
+    return `
+        <div style="font-family: Arial, sans-serif; color: #1c1917; line-height: 1.5;">
+            <h1 style="font-size: 20px;">Nova consulta agendada pelo site</h1>
+            <table style="border-collapse: collapse;">
+                <tbody>
+                    ${rows
+                        .map(
+                            ([label, value]) => `
+                                <tr>
+                                    <td style="padding: 6px 16px 6px 0; color: #57534e;">${escapeHtml(label)}</td>
+                                    <td style="padding: 6px 0; font-weight: 600;">${escapeHtml(value)}</td>
+                                </tr>
+                            `
+                        )
+                        .join("")}
+                </tbody>
+            </table>
+            ${
+                variables.ADMIN_URL
+                    ? `<p><a href="${escapeHtml(variables.ADMIN_URL)}">Abrir no admin</a></p>`
+                    : ""
+            }
+        </div>
+    `;
+}
+
+export async function notifyConsultaCompleted(consultation) {
+    const apiKey = process.env.RESEND_API_KEY;
+    const from =
+        process.env.RESEND_FROM ||
+        "Dra. Lorraine <notificacoes@dralorraine.com>";
+    const to = parseRecipients(process.env.CONSULTA_COMPLETED_EMAIL_TO);
+    const templateId = process.env.RESEND_CONSULTA_COMPLETED_TEMPLATE_ID;
+
+    if (!apiKey || !to.length) {
+        return {
+            skipped: true,
+            missing: [
+                !apiKey ? "RESEND_API_KEY" : null,
+                !to.length ? "CONSULTA_COMPLETED_EMAIL_TO" : null
+            ].filter(Boolean)
+        };
+    }
+
+    const variables = buildTemplateVariables(consultation);
+    const subject = `Nova consulta agendada: ${variables.PATIENT_NAME}`;
+    const message = buildCompletedMessage(consultation);
+    const payload = {
+        from,
+        to,
+        subject,
+        tags: [
+            { name: "event", value: "consulta_completed" },
+            { name: "consultation_id", value: variables.CONSULTATION_ID }
+        ]
+    };
+
+    if (templateId) {
+        payload.template = {
+            id: templateId,
+            variables
+        };
+    } else {
+        payload.text = message;
+        payload.html = buildFallbackHtml(variables);
+    }
+
+    const response = await fetch("https://api.resend.com/emails", {
+        method: "POST",
+        headers: {
+            Authorization: `Bearer ${apiKey}`,
+            "Content-Type": "application/json",
+            "Idempotency-Key": `consulta-completed-${variables.CONSULTATION_ID}-${String(
+                consultation.scheduledAt || ""
+            )}`
+        },
+        body: JSON.stringify(payload)
+    });
+
+    if (!response.ok) {
+        const body = await response.json().catch(() => ({}));
+        throw new Error(
+            body?.message || `Resend notification failed with ${response.status}`
+        );
+    }
+
+    const body = await response.json().catch(() => ({}));
+    return { ok: true, id: body.id };
+}
+
+async function sendResendTemplateEmail({
+    templateId,
+    to,
+    subject,
+    variables,
+    eventName,
+    idempotencyKey
+}) {
+    const apiKey = process.env.RESEND_API_KEY;
+    const from =
+        process.env.RESEND_FROM ||
+        "Dra. Lorraine <notificacoes@dralorraine.com>";
+    const recipients = Array.isArray(to) ? to : parseRecipients(to);
+
+    if (!apiKey || !templateId || !recipients.length) {
+        return {
+            skipped: true,
+            missing: [
+                !apiKey ? "RESEND_API_KEY" : null,
+                !templateId ? "templateId" : null,
+                !recipients.length ? "to" : null
+            ].filter(Boolean)
+        };
+    }
+
+    const response = await fetch("https://api.resend.com/emails", {
+        method: "POST",
+        headers: {
+            Authorization: `Bearer ${apiKey}`,
+            "Content-Type": "application/json",
+            "Idempotency-Key": idempotencyKey
+        },
+        body: JSON.stringify({
+            from,
+            to: recipients,
+            subject,
+            template: {
+                id: templateId,
+                variables
+            },
+            tags: [
+                { name: "event", value: eventName },
+                { name: "consultation_id", value: variables.CONSULTATION_ID }
+            ]
+        })
+    });
+
+    if (!response.ok) {
+        const body = await response.json().catch(() => ({}));
+        throw new Error(
+            body?.message || `Resend notification failed with ${response.status}`
+        );
+    }
+
+    const body = await response.json().catch(() => ({}));
+    return { ok: true, id: body.id };
+}
+
+export async function notifyConsultaPaymentConfirmed(consultation, options = {}) {
+    const variables = getConsultaPaymentTemplateVariables(consultation);
+    const adminRecipients =
+        options.adminRecipients ||
+        process.env.CONSULTA_ADMIN_EMAIL_TO ||
+        "adias7882@gmail.com,lorraine.tfc@gmail.com";
+    const patientRecipient = options.patientRecipient || variables.PATIENT_MAIL;
+    const paymentRef =
+        variables.PAYMENT_PROVIDER_REF || variables.CONSULTATION_ID;
+
+    const [admin, patient] = await Promise.all([
+        sendResendTemplateEmail({
+            templateId: process.env.RESEND_ADMIN_APPOINTMENT_PURCHASED_TEMPLATE_ID,
+            to: adminRecipients,
+            subject: `Nova consulta comprada: ${variables.PATIENT_NAME}`,
+            variables,
+            eventName: "consulta_payment_admin",
+            idempotencyKey: `consulta-payment-admin-${variables.CONSULTATION_ID}-${paymentRef}`
+        }),
+        sendResendTemplateEmail({
+            templateId: process.env.RESEND_PATIENT_PAYMENT_CONFIRMED_TEMPLATE_ID,
+            to: patientRecipient,
+            subject: "Pagamento confirmado - agende sua consulta",
+            variables,
+            eventName: "consulta_payment_patient",
+            idempotencyKey: `consulta-payment-patient-${variables.CONSULTATION_ID}-${paymentRef}`
+        })
+    ]);
+
+    return { admin, patient };
+}
+
+export async function safeNotifyConsultaPaymentConfirmed(consultation, options = {}) {
+    try {
+        return await notifyConsultaPaymentConfirmed(consultation, options);
+    } catch (err) {
+        console.error("[consulta payment notification error]", err);
+        return { error: err?.message || "Payment notification failed" };
+    }
+}
+
+export async function safeNotifyConsultaCompleted(consultation) {
+    try {
+        return await notifyConsultaCompleted(consultation);
+    } catch (err) {
+        console.error("[consulta notification error]", err);
+        return { error: err?.message || "Notification failed" };
+    }
+}


### PR DESCRIPTION
## Summary
- Adds Resend-powered email notifications for paid consultation flows
- Adds admin and patient Resend HTML templates for appointment purchase/payment confirmation
- Adds a local-only dev endpoint to preview/send test consultation emails
- Updates `/consulta` SEO/copy from Cosmeatria to Dermatologia
- Adds a “Foco do atendimento” section covering cosmiatria, dermatologia clínica, and dermatologia cirúrgica
- Clarifies when teleconsultation may require a presencial follow-up step

## Testing
- `npm run lint`
- `npm run build`
- Local Resend test via `/api/dev/consulta-payment-emails`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automated email notifications for consultation payments and appointment confirmations sent to both patients and administrators.

* **Documentation**
  * Added comprehensive documentation for consultation notification configuration, including required environment variables, email templates, and testing guidance.

* **Updates**
  * Rebranded service offering from cosmeatry to dermatology across all customer-facing pages.
  * Updated privacy policy and terms of use to reflect service rebranding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->