### PR TITLE
Fix consulta scheduling form crash on Terms step

### DIFF
--- a/pages/consulta/agendar/index.js
+++ b/pages/consulta/agendar/index.js
@@ -1081,7 +1081,7 @@ function StepPhotos({ data, update, onNext, onBack }) {
                 </button>
                 <button
                     type="button"
-                    onClick={onNext}
+                    onClick={() => onNext()}
                     disabled={uploading}
                     className="bg-[#1C1917] hover:bg-[#9A4639] disabled:bg-[#E7E2D9] disabled:text-[#A8A29E] text-[#FAF6F0] font-medium px-8 py-3.5 rounded-none transition-colors duration-300"
                 >


### PR DESCRIPTION
Fixes a crash in the /consulta/agendar flow when users reached the “Termos” step.

The Photos step was passing React’s click event directly into onNext. The shared next helper treated that event as a data patch and merged it into the form state. Later, the Terms step tried to submit the intake payload with JSON.stringify, which failed because React events contain cyclic references.

This updates the Photos continue button to call onNext() explicitly, preventing the click event from entering form data.

**Validation:**
npm run lint passed. Existing unrelated <img> warnings remain.